### PR TITLE
Fix: Solved 3D house model issue by changing its scale & position

### DIFF
--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -3,8 +3,8 @@ import { Canvas, useThree } from "@react-three/fiber";
 import { OrbitControls, useGLTF } from "@react-three/drei";
 import * as THREE from "three";
 
-// Load the model
-function Model({ scale }) {
+// Load the model 
+function Model({ ...props }) {
   const { scene } = useGLTF("./public/model/SiittngRmBaked.glb"); // Ensure the model is in 'public/model/'
 
   scene.traverse((child) => {
@@ -22,7 +22,7 @@ function Model({ scale }) {
       }
     }
   });
-  return <primitive object={scene} scale={[scale, scale, scale]} />;
+  return <primitive object={scene} {...props} />;
 }
 
 // Resize handling component
@@ -64,7 +64,7 @@ function Experience() {
         maxAzimuthAngle={Math.PI / 4}
         maxPolarAngle={Math.PI / 2}
         minPolarAngle={0}
-        maxDistance={10}
+        maxDistance={30}
         minDistance={2}
         enablePan={false}
       />
@@ -76,9 +76,18 @@ function Experience() {
       <ambientLight intensity={0.5} />
       <directionalLight position={[5, 10, 5]} intensity={1} />
 
+      {/* AxesHelper - length is '1' */}
+      <axesHelper args={[1]} />
+
+      {/* A box to check the model scale */}
+      <mesh>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshNormalMaterial wireframe={true} />
+      </mesh>
+
       {/* Load the model */}
       <Suspense fallback={null}>
-        <Model scale={3} />
+        <Model scale={1.0} position={[0, -2.5, 0]} rotation={[0, 0, 0]} />
       </Suspense>
     </Canvas>
   );


### PR DESCRIPTION
Hey, Emmanuel

I checked the code and the reason why the model showed up above the camera was due to two reasons;

- Model scale and position
- Camera position

I didn't change the camera at all, but I changed the house model scale and position (scale down & move the model down).

I don't know what is your workflow, but when I work on 3D projects, I used "axeshelper" & "wireframed box" as the guide since the default their size is "1" and it's easy to measure scales & positions of models. So I added them also to your code. I hope this makes sense for you, too.

<img width="1065" alt="axeshelper-guide" src="https://github.com/user-attachments/assets/37a2b13c-108b-494b-b3c6-1407d2af500b" />

By the way, the model looks awesome, great job!!
